### PR TITLE
Support Markdown 3.4 compatibility

### DIFF
--- a/mdx_outline.py
+++ b/mdx_outline.py
@@ -137,10 +137,10 @@ See also
 
 
 import re
+from xml.etree import ElementTree
 
 from markdown import Extension
 from markdown.treeprocessors import Treeprocessor
-from markdown.util import etree
 
 __version__ = "1.3.0"
 
@@ -157,7 +157,7 @@ class OutlineProcessor(Treeprocessor):
             if match:
                 depth = int(match.group(1))
 
-                section = etree.SubElement(node, self.wrapper_tag)
+                section = ElementTree.SubElement(node, self.wrapper_tag)
                 section.append(child)
 
                 if self.move_attrib:


### PR DESCRIPTION
Markdown 3.4 finally removed objects that had been tagged as deprecated - see the [release notes](https://github.com/Python-Markdown/markdown/blob/master/docs/change_log/release-3.4.md#previously-deprecated-objects-have-been-removed) for details.

This changeset allows mdx_outline to continue to work when installed with `markdown>=3.4`. 

It replaces the import of `markdown.util.etree` entirely, but I don't feel that a try/except backwards compatibility import is needed because `xml.etree.ElementTree` and `SubElement` are available right back to Python 3.5.