### PR TITLE
Further fixups related to Markdown 3.4

### DIFF
--- a/mdx_outline.py
+++ b/mdx_outline.py
@@ -219,10 +219,10 @@ class OutlineExtension(Extension):
         }
         super(OutlineExtension, self).__init__(**kwargs)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md, md_globals=None):
         ext = OutlineProcessor(md)
         ext.config = self.config
-        md.treeprocessors.add("outline", ext, "_end")
+        md.treeprocessors.register(ext, "outline", 10)
 
 
 def makeExtension(configs={}):

--- a/setup.py
+++ b/setup.py
@@ -3,24 +3,25 @@
 
 from setuptools import setup
 
-
 setup(
-    name='mdx_outline',
-    version='1.3.0',
-    author='Alexandre Leray',
-    author_email='alexandre@stdin.fr',
-    description='Python-Markdown extension to wrap the document logical sections (as implied by h1-h6 headings)',
-    url='http://activearchives.org/',
-    py_modules=['mdx_outline'],
-    install_requires=['Markdown>=2.0',],
+    name="mdx_outline",
+    version="1.3.0",
+    author="Alexandre Leray",
+    author_email="alexandre@stdin.fr",
+    description="Python-Markdown extension to wrap the document logical sections (as implied by h1-h6 headings)",
+    url="http://activearchives.org/",
+    py_modules=["mdx_outline"],
+    install_requires=[
+        "Markdown>=3.4",
+    ],
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Operating System :: OS Independent',
-        'License :: OSI Approved :: BSD License',
-        'Intended Audience :: Developers',
-        'Environment :: Web Environment',
-        'Programming Language :: Python',
-        'Topic :: Text Processing :: Filters',
-        'Topic :: Text Processing :: Markup :: HTML'
-    ]
+        "Development Status :: 4 - Beta",
+        "Operating System :: OS Independent",
+        "License :: OSI Approved :: BSD License",
+        "Intended Audience :: Developers",
+        "Environment :: Web Environment",
+        "Programming Language :: Python",
+        "Topic :: Text Processing :: Filters",
+        "Topic :: Text Processing :: Markup :: HTML",
+    ],
 )


### PR DESCRIPTION
* md_globals needed support as an optional var
* treeprocessors.add was replaced with .register - I missed that one when looking at https://github.com/Python-Markdown/markdown/blob/master/docs/change_log/release-3.4.md#previously-deprecated-objects-have-been-removed